### PR TITLE
Enable AndroidX support in Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier in Gradle configuration

## Testing
- `make apk` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a625def788325a8c3e456ceed9833