### PR TITLE
Fix repeat behavior and avoid immediate task repeats

### DIFF
--- a/app/src/main/java/com/example/selfinspector/MainActivity.kt
+++ b/app/src/main/java/com/example/selfinspector/MainActivity.kt
@@ -22,23 +22,27 @@ class MainActivity : AppCompatActivity() {
         }
 
         findViewById<android.widget.Button>(R.id.repeatButton).setOnClickListener {
-            playNext()
+            playCurrent()
         }
     }
 
     private fun playRandom() {
         if (audioFiles.isEmpty()) return
-        currentIndex = Random.nextInt(audioFiles.size)
-        playCurrent()
-    }
-
-    private fun playNext() {
-        if (audioFiles.isEmpty()) return
-        currentIndex = (currentIndex + 1) % audioFiles.size
+        val newIndex = if (audioFiles.size == 1) {
+            0
+        } else {
+            var candidate: Int
+            do {
+                candidate = Random.nextInt(audioFiles.size)
+            } while (candidate == currentIndex)
+            candidate
+        }
+        currentIndex = newIndex
         playCurrent()
     }
 
     private fun playCurrent() {
+        if (currentIndex !in audioFiles.indices) return
         try {
             mediaPlayer?.release()
             val fileName = audioFiles[currentIndex]


### PR DESCRIPTION
## Summary
- Ensure "Repeat" button replays the last task instead of moving forward
- Prevent consecutive duplication when choosing a random task

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a70564a7c832580e9a714b7e2134b